### PR TITLE
ci: disable signature in ci workflow & strip the build target of android ci workflow 

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,4 +1,4 @@
-name: ci-android(beta) # 
+name: ci-android(beta) #
 
 on: ["push","pull_request"]
 
@@ -18,9 +18,9 @@ jobs:
           distribution: 'zulu'
           java-version: '17' # Tauri use gradle  8.4, which is not supported by Java21 in Github Action Image
       - name: Update Rust Toolchain
-        run: rustup update 
+        run: rustup update
       - name: Install Rust Target
-        run: rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android 
+        run: rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
       - name: Install Node
         uses: actions/setup-node@v4
         with:
@@ -49,4 +49,4 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: echo "NDK_HOME=$env:ANDROID_NDK_HOME" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Tauri build(Android)
-        run: pnpm tauri android build
+        run: pnpm tauri android build --target aarch64 armv7

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Update Rust Toolchain
         run: rustup update
       - name: Install Rust Target
-        run: rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
+        run: rustup target add aarch64-linux-android
       - name: Install Node
         uses: actions/setup-node@v4
         with:
@@ -49,4 +49,4 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: echo "NDK_HOME=$env:ANDROID_NDK_HOME" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Tauri build(Android)
-        run: pnpm tauri android build --target aarch64 armv7
+        run: pnpm tauri android build --target aarch64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,4 +60,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tauriScript: pnpm tauri
-          args: --target ${{ matrix.target }} -b ${{ matrix.bundle }} --config "src-tauri/tauri.conf.debug.json"
+          args: --target ${{ matrix.target }} -b ${{ matrix.bundle }} --config src-tauri/tauri.conf.debug.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,4 +60,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tauriScript: pnpm tauri
-          args: --target ${{ matrix.target }} -b ${{ matrix.bundle }} --config src-tauri/tauri.conf.debug.json
+          args: --target ${{ matrix.target }} -b ${{ matrix.bundle }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
         env:
           NODE_OPTIONS: "--max_old_space_size=4096"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{secrets.TAURI_SIGNING_PRIVATE_KEY}}
         with:
           tauriScript: pnpm tauri
-          args: --target ${{ matrix.target }} -b ${{ matrix.bundle }}
+          args: --target ${{ matrix.target }} -b ${{ matrix.bundle }} --config "src-tauri/tauri.conf.debug.json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,5 +85,5 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{secrets.TAURI_SIGNING_PRIVATE_KEY}}
         with:
           tauriScript: pnpm tauri
-          args: --target ${{ matrix.target }} -b ${{ matrix.bundle }}
+          args: --target ${{ matrix.target }} -b ${{ matrix.bundle }}  --config src-tauri/tauri.conf.release.json
           tagName: ${{ needs.release-please.outputs.jinhsi-studio--tag_name }}

--- a/src-tauri/capabilities/desktop.json
+++ b/src-tauri/capabilities/desktop.json
@@ -2,6 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "desktop",
   "description": "Capability for the desktop application",
+  "windows": ["main"],
   "platforms": ["linux", "macOS", "windows"],
   "permissions": ["updater:default"]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,7 +13,11 @@ pub fn run() {
             cmd::gacha::update_gachalog_from_url,
             cmd::gacha::update_gachalog_from_local,
         ]);
-    #[cfg(all(desktop, debug_assertions, dev))]
+    #[cfg(all(
+        not(any(target_os = "android", target_os = "ios")),
+        debug_assertions,
+        dev
+    ))]
     let builder = builder.plugin(tauri_plugin_updater::Builder::new().build());
     builder
         .run(tauri::generate_context!())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,7 +13,7 @@ pub fn run() {
             cmd::gacha::update_gachalog_from_url,
             cmd::gacha::update_gachalog_from_local,
         ]);
-    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    #[cfg(all(desktop, debug_assertions, dev))]
     let builder = builder.plugin(tauri_plugin_updater::Builder::new().build());
     builder
         .run(tauri::generate_context!())

--- a/src-tauri/tauri.conf.debug.json
+++ b/src-tauri/tauri.conf.debug.json
@@ -30,15 +30,6 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ],
-    "createUpdaterArtifacts": true
-  },
-  "plugins": {
-    "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDg1QkFFNkU5MkU3QjA3M0YKUldRL0Izc3U2ZWE2aFdUanpPcndyKzkzWmV5akVkTlY0REIyQlNrS2RmR3M3OHFVWlQydGJuSmQK",
-      "endpoints": [
-        "https://github.com/JinhsiStudio/JinhsiStudio/releases/latest/download/latest.json"
-      ]
-    }
+    ]
   }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -30,15 +30,6 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ],
-    "createUpdaterArtifacts": true
-  },
-  "plugins": {
-    "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDg1QkFFNkU5MkU3QjA3M0YKUldRL0Izc3U2ZWE2aFdUanpPcndyKzkzWmV5akVkTlY0REIyQlNrS2RmR3M3OHFVWlQydGJuSmQK",
-      "endpoints": [
-        "https://github.com/JinhsiStudio/JinhsiStudio/releases/latest/download/latest.json"
-      ]
-    }
+    ]
   }
 }

--- a/src-tauri/tauri.conf.release.json
+++ b/src-tauri/tauri.conf.release.json
@@ -30,6 +30,15 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "createUpdaterArtifacts": true
+  },
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDg1QkFFNkU5MkU3QjA3M0YKUldRL0Izc3U2ZWE2aFdUanpPcndyKzkzWmV5akVkTlY0REIyQlNrS2RmR3M3OHFVWlQydGJuSmQK",
+      "endpoints": [
+        "https://github.com/JinhsiStudio/JinhsiStudio/releases/latest/download/latest.json"
+      ]
+    }
   }
 }


### PR DESCRIPTION
1. Only signing in release workflow to avoid leaking private key and some ci workflow failure
2. Strip the build targets of android ci workflow to aarch64 to boost the ci workflow