### PR TITLE
fix: a launch panic caused by using cfg macro incorrectly

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,8 +15,8 @@ pub fn run() {
         ]);
     #[cfg(all(
         not(any(target_os = "android", target_os = "ios")),
-        debug_assertions,
-        dev
+        not(debug_assertions),
+        not(dev)
     ))]
     let builder = builder.plugin(tauri_plugin_updater::Builder::new().build());
     builder


### PR DESCRIPTION
修复了由于错误地使用了cfg宏引起的启动崩溃

Fix a launch panic caused by using cfg macro incorrectly